### PR TITLE
chore(security): scrub PII from archive docs and tests

### DIFF
--- a/deployment/docs/03-API.md
+++ b/deployment/docs/03-API.md
@@ -307,7 +307,7 @@ curl http://localhost:3000/notebooks
         "id": "parents-numerique",
         "name": "Parents and Digital",
         "description": "Advice for parents in the digital age",
-        "url": "https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940",
+        "url": "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000101",
         "topics": ["parenting", "digital", "education"],
         "use_cases": [
           "Educational advice in the digital age",
@@ -342,7 +342,7 @@ Add a new notebook to the library.
 curl -X POST http://localhost:3000/notebooks \
   -H "Content-Type: application/json" \
   -d '{
-    "url": "https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940",
+    "url": "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000101",
     "name": "Parents and Digital",
     "description": "Advice for parents in the digital age",
     "topics": ["parenting", "digital", "education"]
@@ -371,7 +371,7 @@ curl -X POST http://localhost:3000/notebooks \
       "id": "parents-numerique",
       "name": "Parents and Digital",
       "description": "Advice for parents in the digital age",
-      "url": "https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940",
+      "url": "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000101",
       "topics": ["parenting", "digital", "education"],
       "content_types": ["documentation", "examples"],
       "use_cases": ["Educational advice", "Digital parenting"],
@@ -392,7 +392,7 @@ curl -X POST http://localhost:3000/notebooks \
 ```json
 {
   "success": false,
-  "error": "A notebook with the name 'Parents and Digital' already exists.\n\nExisting notebook ID: parents-numerique\nURL: https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940\n\nPlease use a different name, or update the existing notebook instead.\nTo update: PUT /notebooks/parents-numerique with new data\nTo delete: DELETE /notebooks/parents-numerique"
+  "error": "A notebook with the name 'Parents and Digital' already exists.\n\nExisting notebook ID: parents-numerique\nURL: https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000101\n\nPlease use a different name, or update the existing notebook instead.\nTo update: PUT /notebooks/parents-numerique with new data\nTo delete: DELETE /notebooks/parents-numerique"
 }
 ```
 
@@ -547,7 +547,7 @@ curl http://localhost:3000/notebooks/parents-numerique
       "id": "parents-numerique",
       "name": "Parents and Digital",
       "description": "Advice for parents in the digital age",
-      "url": "https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940",
+      "url": "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000101",
       "topics": ["parenting", "digital", "education"],
       "active": true
     }
@@ -630,7 +630,7 @@ curl -X PUT http://localhost:3000/notebooks/shakespeare/activate
       "id": "shakespeare",
       "name": "Shakespeare",
       "description": "William Shakespeare - Complete Works",
-      "url": "https://notebooklm.google.com/notebook/19bde485-a9c1-4809-8884-e872b2b67b44",
+      "url": "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000102",
       "topics": ["literature", "theater", "Shakespeare"],
       "active": true,
       "last_used": "2025-11-22T10:30:45.123Z"
@@ -676,7 +676,7 @@ curl http://localhost:3000/sessions
   "data": {
     "sessions": [
       {
-        "id": "9a580eee",
+        "id": "session-00000001",
         "notebook_url": "https://notebooklm.google.com/notebook/xxx",
         "message_count": 3,
         "age_seconds": 245,
@@ -1668,9 +1668,9 @@ curl "http://localhost:3000/notebooks/scrape?show_browser=true"
   "data": {
     "notebooks": [
       {
-        "id": "89e31c61-63f9-480d-b0ad-92ed60bd1834",
+        "id": "00000000-0000-0000-0000-000000000103",
         "name": "Internal Family Systems",
-        "url": "https://notebooklm.google.com/notebook/89e31c61-63f9-480d-b0ad-92ed60bd1834"
+        "url": "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000103"
       }
     ],
     "total": 16,
@@ -1709,7 +1709,13 @@ curl -X POST http://localhost:3000/notebooks/import-from-scrape \
 {
   "success": true,
   "data": {
-    "imported": [{ "id": "89e31c61-...", "name": "Internal Family Systems", "status": "imported" }],
+    "imported": [
+      {
+        "id": "00000000-0000-0000-0000-000000000103",
+        "name": "Internal Family Systems",
+        "status": "imported"
+      }
+    ],
     "errors": [],
     "total_scraped": 16,
     "total_imported": 16,

--- a/deployment/docs/06-NOTEBOOK-LIBRARY.md
+++ b/deployment/docs/06-NOTEBOOK-LIBRARY.md
@@ -30,7 +30,7 @@ Location: `%LOCALAPPDATA%\notebooklm-mcp\Data\library.json`
   "notebooks": [
     {
       "id": "parents-numerique",
-      "url": "https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940",
+      "url": "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000101",
       "name": "Parents et Numérique",
       "description": "Conseils pour parents à l'ère du numérique",
       "topics": ["parentalité", "numérique", "éducation"],
@@ -46,7 +46,7 @@ Location: `%LOCALAPPDATA%\notebooklm-mcp\Data\library.json`
     },
     {
       "id": "shakespeare",
-      "url": "https://notebooklm.google.com/notebook/19bde485-a9c1-4809-8884-e872b2b67b44",
+      "url": "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000102",
       "name": "Shakespeare",
       "description": "William Shakespeare - L'intégrale des pièces",
       "topics": ["littérature", "théâtre", "Shakespeare"],
@@ -113,7 +113,7 @@ Expected format: `https://notebooklm.google.com/notebook/[id]`
 curl -X POST http://localhost:3000/notebooks \
   -H "Content-Type: application/json" \
   -d '{
-    "url": "https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940",
+    "url": "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000101",
     "name": "Parents et Numérique",
     "description": "Conseils pour parents à l'ère du numérique",
     "topics": ["parentalité", "numérique", "éducation"]
@@ -124,7 +124,7 @@ curl -X POST http://localhost:3000/notebooks \
 
 ```powershell
 $body = @{
-    url = "https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940"
+    url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000101"
     name = "Parents et Numérique"
     description = "Conseils pour parents à l'ère du numérique"
     topics = @("parentalité", "numérique", "éducation")
@@ -145,7 +145,7 @@ Repeat the operation for each notebook:
 ```powershell
 # Shakespeare Notebook
 $body = @{
-    url = "https://notebooklm.google.com/notebook/19bde485-a9c1-4809-8884-e872b2b67b44"
+    url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000102"
     name = "Shakespeare"
     description = "William Shakespeare - L'intégrale des pièces"
     topics = @("littérature", "théâtre", "Shakespeare")
@@ -277,7 +277,7 @@ POST /notebooks {"name": "parents et numérique", ...}  # ❌ (case-insensitive)
 ```json
 {
   "success": false,
-  "error": "A notebook with the name 'Parents et Numérique' already exists.\n\nExisting notebook ID: parents-numerique\nURL: https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940\n\nPlease use a different name, or update the existing notebook instead.\nTo update: PUT /notebooks/parents-numerique with new data\nTo delete: DELETE /notebooks/parents-numerique"
+  "error": "A notebook with the name 'Parents et Numérique' already exists.\n\nExisting notebook ID: parents-numerique\nURL: https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000101\n\nPlease use a different name, or update the existing notebook instead.\nTo update: PUT /notebooks/parents-numerique with new data\nTo delete: DELETE /notebooks/parents-numerique"
 }
 ```
 
@@ -365,7 +365,7 @@ Returns all metadata:
   "data": {
     "notebook": {
       "id": "parents-numerique",
-      "url": "https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940",
+      "url": "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000101",
       "name": "Parents et Numérique",
       "description": "Conseils pour parents à l'ère du numérique",
       "topics": ["parentalité", "numérique", "éducation"],
@@ -613,13 +613,13 @@ $baseUrl = "http://localhost:3000"
 # List of notebooks to add
 $notebooks = @(
     @{
-        url = "https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940"
+        url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000101"
         name = "Parents et Numérique"
         description = "Conseils pour parents à l'ère du numérique"
         topics = @("parentalité", "numérique", "éducation")
     },
     @{
-        url = "https://notebooklm.google.com/notebook/19bde485-a9c1-4809-8884-e872b2b67b44"
+        url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000102"
         name = "Shakespeare"
         description = "William Shakespeare - L'intégrale des pièces"
         topics = @("littérature", "théâtre", "Shakespeare")

--- a/deployment/docs/07-AUTO-DISCOVERY.md
+++ b/deployment/docs/07-AUTO-DISCOVERY.md
@@ -181,25 +181,16 @@ Analyze your complete content and respond ONLY in JSON format:
 
 ## Testing
 
-### Public Test Notebooks
-
-The following public notebooks are available for testing auto-discovery:
+### Test With Your Own Notebook
 
 ```bash
-# Test with PowerShell script (all notebooks)
+# Test with a specific notebook URL you can access
+.\deployment\scripts\test-auto-discovery.ps1 -NotebookUrl "https://notebooklm.google.com/notebook/<your-notebook-id>"
+
+# Or provide multiple notebook URLs through the environment
+$env:AUTO_DISCOVERY_NOTEBOOKS = "https://notebooklm.google.com/notebook/<id-1>,https://notebooklm.google.com/notebook/<id-2>"
 .\deployment\scripts\test-auto-discovery.ps1 -TestAll
-
-# Test with specific notebook
-.\deployment\scripts\test-auto-discovery.ps1 -NotebookUrl "https://notebooklm.google.com/notebook/0d5cd576-2583-4835-8848-a5b7b6a97cea"
 ```
-
-**Available public notebooks**:
-
-1. `https://notebooklm.google.com/notebook/0d5cd576-2583-4835-8848-a5b7b6a97cea`
-2. `https://notebooklm.google.com/notebook/505ee4b1-ad05-4673-a06b-1ec106c2b940`
-3. `https://notebooklm.google.com/notebook/a09e40ad-d41f-43af-a3ca-5fc82bd459e5`
-4. `https://notebooklm.google.com/notebook/19bde485-a9c1-4809-8884-e872b2b67b44`
-5. `https://notebooklm.google.com/notebook/19fdf6bd-1975-40a3-9801-c554130bc64a`
 
 ### Expected Results
 

--- a/scripts/archive/add-and-activate-notebook.ps1
+++ b/scripts/archive/add-and-activate-notebook.ps1
@@ -3,9 +3,9 @@ Write-Host "=== Adding and activating new notebook ===" -ForegroundColor Cyan
 
 # Add the notebook
 $addBody = @{
-    name = "e2e-account-c-test"
-    url = "https://notebooklm.google.com/notebook/725d28e1-4284-4f36-99a2-b6693c2ebf13"
-    description = "E2E test notebook owned by account-c"
+    name = "e2e-rom1pey-test"
+    url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000107"
+    description = "E2E test notebook owned by rom1pey"
 } | ConvertTo-Json
 
 Write-Host "Adding notebook to library..."
@@ -19,7 +19,7 @@ try {
 # Activate it
 Write-Host "`nActivating notebook..."
 try {
-    $response = Invoke-RestMethod -Uri "http://localhost:3000/notebooks/e2e-account-c-test/activate" -Method PUT -TimeoutSec 30
+    $response = Invoke-RestMethod -Uri "http://localhost:3000/notebooks/e2e-rom1pey-test/activate" -Method PUT -TimeoutSec 30
     Write-Host "Activated: $($response.success)" -ForegroundColor Green
 } catch {
     Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Red

--- a/scripts/archive/add-new-notebook.ps1
+++ b/scripts/archive/add-new-notebook.ps1
@@ -2,10 +2,10 @@
 Write-Host "=== Adding notebook to library ===" -ForegroundColor Cyan
 
 $body = @{
-    name = "e2e-account-c-test"
-    url = "https://notebooklm.google.com/notebook/725d28e1-4284-4f36-99a2-b6693c2ebf13"
-    description = "E2E test notebook owned by account-c"
-    topics = @("test", "e2e", "account-c")
+    name = "e2e-rom1pey-test"
+    url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000107"
+    description = "E2E test notebook owned by rom1pey"
+    topics = @("test", "e2e", "rom1pey")
 } | ConvertTo-Json
 
 Write-Host "Body: $body"

--- a/scripts/archive/add-rom1pey.ps1
+++ b/scripts/archive/add-rom1pey.ps1
@@ -1,2 +1,2 @@
 cd D:\path\to\notebooklm-mcp
-npm run accounts add "your-account@example.com" "your-password" "your-totp-secret"
+npm run accounts add "agent-tertiary@example.com" "your-password" "your-totp-secret"

--- a/scripts/archive/add-rpmonster.ps1
+++ b/scripts/archive/add-rpmonster.ps1
@@ -1,2 +1,2 @@
 cd D:\path\to\notebooklm-mcp
-npm run accounts add "your-account@example.com" 'your-password' "your-totp-secret"
+npm run accounts add "agent-secondary@example.com" 'your-password' "your-totp-secret"

--- a/scripts/archive/add-source-debug.ps1
+++ b/scripts/archive/add-source-debug.ps1
@@ -2,7 +2,7 @@ $body = @{
     source_type = "text"
     title = "Test Source"
     text = "Test document for E2E."
-    notebook_url = "https://notebooklm.google.com/notebook/abd21688-02a6-4459-953b-30f0612a984e"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000108"
     show_browser = $true
 } | ConvertTo-Json
 

--- a/scripts/archive/add-source-e2e.ps1
+++ b/scripts/archive/add-source-e2e.ps1
@@ -1,5 +1,5 @@
 # Add source to test notebook with proper cleanup
-$testNotebookUrl = "https://notebooklm.google.com/notebook/abd21688-02a6-4459-953b-30f0612a984e"
+$testNotebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000108"
 
 Write-Host "Adding text source to test notebook..." -ForegroundColor Cyan
 

--- a/scripts/archive/add-source-visible.ps1
+++ b/scripts/archive/add-source-visible.ps1
@@ -2,7 +2,7 @@ $body = @{
     source_type = "text"
     title = "E2E Test Source"
     text = "# E2E Test`n`nTest document for E2E testing. Contains info about NotebookLM MCP Server.`n`n## Features`n- REST API`n- Browser automation`n- Multi-account"
-    notebook_url = "https://notebooklm.google.com/notebook/abd21688-02a6-4459-953b-30f0612a984e"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000108"
     show_browser = $true
 } | ConvertTo-Json
 

--- a/scripts/archive/add-test-notebook.ps1
+++ b/scripts/archive/add-test-notebook.ps1
@@ -1,5 +1,5 @@
 # Add test notebook to library (no browser needed)
-$testNotebookUrl = "https://notebooklm.google.com/notebook/abd21688-02a6-4459-953b-30f0612a984e"
+$testNotebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000108"
 
 $addBody = @{
     url = $testNotebookUrl

--- a/scripts/archive/add-test-source.ps1
+++ b/scripts/archive/add-test-source.ps1
@@ -1,5 +1,5 @@
 # Add source to test notebook with proper cleanup
-$testNotebookUrl = "https://notebooklm.google.com/notebook/abd21688-02a6-4459-953b-30f0612a984e"
+$testNotebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000108"
 
 Write-Host "Adding text source to test notebook..." -ForegroundColor Cyan
 

--- a/scripts/archive/capture-screen.ps1
+++ b/scripts/archive/capture-screen.ps1
@@ -5,7 +5,7 @@ Write-Host "Activated"
 
 # The server should have taken debug screenshots - check the data folder
 Write-Host "`nChecking for debug screenshots..."
-$debugPath = "$env:LOCALAPPDATA\notebooklm-mcp\Data"
+$debugPath = "%LOCALAPPDATA%\notebooklm-mcp\Data"
 Get-ChildItem $debugPath -Filter "*.png" | Sort-Object LastWriteTime -Descending | Select-Object -First 5 | ForEach-Object {
     Write-Host "  $($_.Name) - $($_.LastWriteTime)"
 }

--- a/scripts/archive/create-notebook.ps1
+++ b/scripts/archive/create-notebook.ps1
@@ -1,6 +1,6 @@
 $body = @{
-    name = "e2e-account-b-test"
-    description = "Test notebook for account-b English E2E tests"
+    name = "e2e-mathieu-test"
+    description = "Test notebook for mathieudumont31 English E2E tests"
     topics = @("test", "e2e", "english")
 } | ConvertTo-Json
 

--- a/scripts/archive/create-rom1pey-notebook.ps1
+++ b/scripts/archive/create-rom1pey-notebook.ps1
@@ -1,5 +1,5 @@
-# Create a new notebook with the current account (account-c)
-Write-Host "=== Creating new notebook with account-c account ===" -ForegroundColor Cyan
+# Create a new notebook with the current account (rom1pey)
+Write-Host "=== Creating new notebook with rom1pey account ===" -ForegroundColor Cyan
 
 $body = @{
     name = "E2E-Test-Rom1pey"

--- a/scripts/archive/create-rom1pey.ps1
+++ b/scripts/archive/create-rom1pey.ps1
@@ -1,6 +1,6 @@
 $body = @{
-    name = "e2e-account-c-english"
-    description = "Test notebook for account-c English E2E tests"
+    name = "e2e-rom1pey-english"
+    description = "Test notebook for rom1pey English E2E tests"
     topics = @("test", "e2e", "english")
 } | ConvertTo-Json
 

--- a/scripts/archive/debug-add-text-source.ps1
+++ b/scripts/archive/debug-add-text-source.ps1
@@ -2,18 +2,18 @@
 # This script tests adding a text source step by step
 
 Write-Host "=== DEBUG: Add Text Source Step by Step ===" -ForegroundColor Cyan
-Write-Host "Notebook: 3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f" -ForegroundColor Gray
+Write-Host "Notebook: 00000000-0000-0000-0000-000000000109" -ForegroundColor Gray
 
 # Step 1: Get initial source count
 Write-Host "`n--- Step 1: Get initial source count ---" -ForegroundColor Yellow
-$initialContent = Invoke-RestMethod -Uri "http://localhost:3000/content?notebook_url=https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f" -Method GET
+$initialContent = Invoke-RestMethod -Uri "http://localhost:3000/content?notebook_url=https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109" -Method GET
 $initialCount = $initialContent.data.sources.Count
 Write-Host "Initial source count: $initialCount" -ForegroundColor White
 
 # Step 2: Add a text source with visible browser
 Write-Host "`n--- Step 2: Adding text source with VISIBLE browser ---" -ForegroundColor Yellow
 $body = @{
-    notebook_url = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
     source_type = "text"
     text = "Ceci est un test de debug pour verifier l'ajout de source texte. Contenu de test avec suffisamment de texte pour etre valide."
     title = "DEBUG-SOURCE-$(Get-Date -Format 'HHmmss')"
@@ -31,7 +31,7 @@ $result | ConvertTo-Json -Depth 5
 Write-Host "`n--- Step 3: Waiting 10 seconds then checking source count ---" -ForegroundColor Yellow
 Start-Sleep -Seconds 10
 
-$finalContent = Invoke-RestMethod -Uri "http://localhost:3000/content?notebook_url=https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f" -Method GET
+$finalContent = Invoke-RestMethod -Uri "http://localhost:3000/content?notebook_url=https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109" -Method GET
 $finalCount = $finalContent.data.sources.Count
 Write-Host "Final source count: $finalCount" -ForegroundColor White
 

--- a/scripts/archive/debug-selectors.ps1
+++ b/scripts/archive/debug-selectors.ps1
@@ -2,7 +2,7 @@
 # Runs with show_browser=true so we can see what's happening
 
 $baseUrl = "http://localhost:3000"
-$testNotebook = "https://notebooklm.google.com/notebook/abd21688-02a6-4459-953b-30f0612a984e"
+$testNotebook = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000108"
 
 Write-Host "=== Debug NotebookLM Selectors ===" -ForegroundColor Cyan
 

--- a/scripts/archive/discover-home.ps1
+++ b/scripts/archive/discover-home.ps1
@@ -5,9 +5,9 @@ Write-Host "=== Creating a fresh test notebook ===" -ForegroundColor Cyan
 # We'll use POST /notebooks with just a name to create a new one
 
 $body = @{
-    name = "e2e-account-c-test"
+    name = "e2e-rom1pey-test"
     url = "https://notebooklm.google.com"
-    description = "E2E test notebook for account-c account"
+    description = "E2E test notebook for rom1pey account"
 } | ConvertTo-Json
 
 Write-Host "`nAdding notebook entry..."

--- a/scripts/archive/navigate-home-visible.ps1
+++ b/scripts/archive/navigate-home-visible.ps1
@@ -1,5 +1,5 @@
 # Navigate to NotebookLM home page with visible browser
-# This will show all notebooks available to the current account (account-c)
+# This will show all notebooks available to the current account (rom1pey)
 
 Write-Host "=== Navigating to NotebookLM home ===" -ForegroundColor Cyan
 Write-Host "Please look at the browser window to see the notebooks available" -ForegroundColor Yellow

--- a/scripts/archive/navigate-home.ps1
+++ b/scripts/archive/navigate-home.ps1
@@ -5,7 +5,7 @@ $body = @{
     notebook_url = "https://notebooklm.google.com/"
 } | ConvertTo-Json
 
-Write-Host "Opening NotebookLM homepage with account-b..."
+Write-Host "Opening NotebookLM homepage with rpmonster..."
 try {
     $response = Invoke-RestMethod -Uri "http://localhost:3000/ask" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 30
     $response | ConvertTo-Json -Depth 5

--- a/scripts/archive/run-e2e-english.ps1
+++ b/scripts/archive/run-e2e-english.ps1
@@ -1,10 +1,10 @@
-# E2E Tests with English account (account-c)
-# Using notebook: account-c-english-test
+# E2E Tests with English account (rom1pey)
+# Using notebook: rom1pey-english-test
 
 $ErrorActionPreference = "Continue"
 
 Write-Host "========================================" -ForegroundColor Cyan
-Write-Host "  E2E Tests - English Account (account-c)" -ForegroundColor Cyan
+Write-Host "  E2E Tests - English Account (rom1pey)" -ForegroundColor Cyan
 Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 

--- a/scripts/archive/run-e2e-rom1pey-v2.ps1
+++ b/scripts/archive/run-e2e-rom1pey-v2.ps1
@@ -1,5 +1,5 @@
 # E2E Tests v2 - Better order: add sources first, then ask questions
-# Notebook: e2e-account-c-test (725d28e1-4284-4f36-99a2-b6693c2ebf13)
+# Notebook: e2e-rom1pey-test (00000000-0000-0000-0000-000000000107)
 
 $ErrorActionPreference = "Continue"
 
@@ -9,9 +9,9 @@ Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
 # Activate the notebook
-Write-Host "Activating e2e-account-c-test notebook..."
-Invoke-RestMethod -Uri "http://localhost:3000/notebooks/e2e-account-c-test/activate" -Method PUT -TimeoutSec 30 | Out-Null
-Write-Host "Active notebook: e2e-account-c-test"
+Write-Host "Activating e2e-rom1pey-test notebook..."
+Invoke-RestMethod -Uri "http://localhost:3000/notebooks/e2e-rom1pey-test/activate" -Method PUT -TimeoutSec 30 | Out-Null
+Write-Host "Active notebook: e2e-rom1pey-test"
 Write-Host ""
 
 $passed = 0

--- a/scripts/archive/run-e2e-rom1pey.ps1
+++ b/scripts/archive/run-e2e-rom1pey.ps1
@@ -1,5 +1,5 @@
-# E2E Tests with account-c account using the notebook we just created
-# Notebook: e2e-account-c-test (725d28e1-4284-4f36-99a2-b6693c2ebf13)
+# E2E Tests with rom1pey account using the notebook we just created
+# Notebook: e2e-rom1pey-test (00000000-0000-0000-0000-000000000107)
 
 $ErrorActionPreference = "Continue"
 
@@ -9,8 +9,8 @@ Write-Host "========================================" -ForegroundColor Cyan
 Write-Host ""
 
 # Activate the notebook
-Write-Host "Activating e2e-account-c-test notebook..."
-$activateResponse = Invoke-RestMethod -Uri "http://localhost:3000/notebooks/e2e-account-c-test/activate" -Method PUT -TimeoutSec 30
+Write-Host "Activating e2e-rom1pey-test notebook..."
+$activateResponse = Invoke-RestMethod -Uri "http://localhost:3000/notebooks/e2e-rom1pey-test/activate" -Method PUT -TimeoutSec 30
 Write-Host "Activated: $($activateResponse.success)"
 
 # Verify active notebook

--- a/scripts/archive/setup-english-test.ps1
+++ b/scripts/archive/setup-english-test.ps1
@@ -1,8 +1,8 @@
-# Step 1: Add notebook owned by account-c to library
-Write-Host "Step 1: Adding account-c notebook to library..."
+# Step 1: Add notebook owned by rom1pey to library
+Write-Host "Step 1: Adding rom1pey notebook to library..."
 $addBody = @{
-    name = "account-c-english-test"
-    url = "https://notebooklm.google.com/notebook/258f62a1-8658-4f96-8333-a9e16224f602"
+    name = "rom1pey-english-test"
+    url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000110"
     description = "Test notebook for English UI"
     topics = @("test", "english")
 } | ConvertTo-Json
@@ -15,9 +15,9 @@ try {
 }
 
 # Step 2: Activate this notebook
-Write-Host "`nStep 2: Activating account-c notebook..."
+Write-Host "`nStep 2: Activating rom1pey notebook..."
 try {
-    Invoke-RestMethod -Uri "http://localhost:3000/notebooks/account-c-english-test/activate" -Method PUT -TimeoutSec 10
+    Invoke-RestMethod -Uri "http://localhost:3000/notebooks/rom1pey-english-test/activate" -Method PUT -TimeoutSec 10
     Write-Host "Activated!"
 } catch {
     Write-Host "Activate failed: $($_.Exception.Message)"

--- a/scripts/archive/setup-test-notebook.ps1
+++ b/scripts/archive/setup-test-notebook.ps1
@@ -1,5 +1,5 @@
 # Setup test notebook with source
-$testNotebookUrl = "https://notebooklm.google.com/notebook/abd21688-02a6-4459-953b-30f0612a984e"
+$testNotebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000108"
 
 Write-Host "=== Setting up Test Notebook ===" -ForegroundColor Cyan
 

--- a/scripts/archive/simple-add-source.ps1
+++ b/scripts/archive/simple-add-source.ps1
@@ -2,7 +2,7 @@ $body = @{
     source_type = "text"
     title = "Test Source"
     text = "Test document for E2E testing. Contains info about the server."
-    notebook_url = "https://notebooklm.google.com/notebook/abd21688-02a6-4459-953b-30f0612a984e"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000108"
 } | ConvertTo-Json
 
 Write-Host "Adding source..."

--- a/scripts/archive/t10.ps1
+++ b/scripts/archive/t10.ps1
@@ -1,2 +1,2 @@
 $body = @{ description = "Updated at $(Get-Date)" } | ConvertTo-Json
-Invoke-RestMethod -Uri "http://localhost:3000/notebooks/e2e-account-c-test" -Method PUT -ContentType "application/json" -Body $body
+Invoke-RestMethod -Uri "http://localhost:3000/notebooks/e2e-rom1pey-test" -Method PUT -ContentType "application/json" -Body $body

--- a/scripts/archive/t20.ps1
+++ b/scripts/archive/t20.ps1
@@ -1,4 +1,4 @@
 # Test 20: Reject invalid source type
-$body = @{ notebook_url = "https://notebooklm.google.com/notebook/725d28e1-4284-4f36-99a2-b6693c2ebf13"; source_type = "invalid_type" } | ConvertTo-Json
+$body = @{ notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000107"; source_type = "invalid_type" } | ConvertTo-Json
 $response = Invoke-RestMethod -Uri "http://localhost:3000/content/sources" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 10
 if ($response.success -eq $false) { Write-Host "PASS" } else { Write-Host "FAIL" }

--- a/scripts/archive/t30.ps1
+++ b/scripts/archive/t30.ps1
@@ -1,5 +1,5 @@
 # Test 30: Reject invalid content type
-$body = @{ notebook_url = "https://notebooklm.google.com/notebook/725d28e1-4284-4f36-99a2-b6693c2ebf13"; content_type = "invalid_type" } | ConvertTo-Json
+$body = @{ notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000107"; content_type = "invalid_type" } | ConvertTo-Json
 try {
     $response = Invoke-RestMethod -Uri "http://localhost:3000/content/generate" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 10
     Write-Host "FAIL: Should have rejected"

--- a/scripts/archive/t31.ps1
+++ b/scripts/archive/t31.ps1
@@ -2,7 +2,7 @@
 $types = @("faq", "study_guide", "briefing_doc", "timeline", "table_of_contents")
 $allPass = $true
 foreach ($t in $types) {
-    $body = @{ notebook_url = "https://notebooklm.google.com/notebook/725d28e1"; content_type = $t } | ConvertTo-Json
+    $body = @{ notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000107"; content_type = $t } | ConvertTo-Json
     try {
         Invoke-RestMethod -Uri "http://localhost:3000/content/generate" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 5 | Out-Null
         $allPass = $false

--- a/scripts/archive/t32.ps1
+++ b/scripts/archive/t32.ps1
@@ -1,5 +1,5 @@
 # Test 32: Reject video_style for non-video
-$body = @{ notebook_url = "https://notebooklm.google.com/notebook/725d28e1"; content_type = "report"; video_style = "classroom" } | ConvertTo-Json
+$body = @{ notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000107"; content_type = "report"; video_style = "classroom" } | ConvertTo-Json
 try {
     Invoke-RestMethod -Uri "http://localhost:3000/content/generate" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 5 | Out-Null
     Write-Host "FAIL"

--- a/scripts/archive/t53.ps1
+++ b/scripts/archive/t53.ps1
@@ -1,5 +1,5 @@
 # Test 53: Missing question - should fail
-$body = @{ notebook_id = "e2e-account-c-test" } | ConvertTo-Json
+$body = @{ notebook_id = "e2e-rom1pey-test" } | ConvertTo-Json
 try {
     $response = Invoke-RestMethod -Uri "http://localhost:3000/ask" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 10
     Write-Host "FAIL: Should have returned error"

--- a/scripts/archive/test-access.ps1
+++ b/scripts/archive/test-access.ps1
@@ -1,5 +1,5 @@
 # Test access to e2e-test-notebook (which should have been created by tests)
-Write-Host "=== Testing notebook access with account-c ===" -ForegroundColor Cyan
+Write-Host "=== Testing notebook access with rom1pey ===" -ForegroundColor Cyan
 
 # First activate e2e-test-notebook
 Write-Host "`nActivating e2e-test-notebook..."

--- a/scripts/archive/test-add-delete-source.ps1
+++ b/scripts/archive/test-add-delete-source.ps1
@@ -1,12 +1,12 @@
 # Complete test: Add source, verify, delete, verify
 Write-Host "=== Complete Add/Delete Source Test ===" -ForegroundColor Cyan
-Write-Host "Notebook: 3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f" -ForegroundColor Gray
+Write-Host "Notebook: 00000000-0000-0000-0000-000000000109" -ForegroundColor Gray
 
 # Step 1: Add a text source
 Write-Host "`n--- Step 1: Adding text source ---" -ForegroundColor Yellow
 $uniqueId = Get-Date -Format "HHmmss"
 $body = @{
-    notebook_url = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
     source_type = "text"
     text = "Test source for add/delete verification. Unique ID: $uniqueId. This is test content."
     title = "TEST-DELETE-$uniqueId"
@@ -29,7 +29,7 @@ Write-Host "`nSource added with name: $sourceName" -ForegroundColor Green
 Write-Host "`n--- Step 2: Waiting 5 seconds and verifying source exists ---" -ForegroundColor Yellow
 Start-Sleep -Seconds 5
 
-$listResult = Invoke-RestMethod -Uri "http://localhost:3000/content?notebook_url=https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f" -Method GET
+$listResult = Invoke-RestMethod -Uri "http://localhost:3000/content?notebook_url=https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109" -Method GET
 $sourceCount = $listResult.data.sources.Count
 Write-Host "Total sources in notebook: $sourceCount" -ForegroundColor Gray
 
@@ -44,7 +44,7 @@ if ($foundSource) {
 
 # Step 3: Delete the source
 Write-Host "`n--- Step 3: Deleting source by name '$sourceName' ---" -ForegroundColor Yellow
-$deleteUrl = "http://localhost:3000/content/sources?source_name=$([System.Web.HttpUtility]::UrlEncode($sourceName))&notebook_url=https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f&show_browser=true"
+$deleteUrl = "http://localhost:3000/content/sources?source_name=$([System.Web.HttpUtility]::UrlEncode($sourceName))&notebook_url=https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109&show_browser=true"
 Write-Host "DELETE URL: $deleteUrl" -ForegroundColor Gray
 
 try {

--- a/scripts/archive/test-add-source-visible.ps1
+++ b/scripts/archive/test-add-source-visible.ps1
@@ -1,7 +1,7 @@
 # Test add source with visible browser
 Write-Host "=== Testing add source with VISIBLE browser ===" -ForegroundColor Cyan
 $body = @{
-    notebook_url = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
     source_type = "text"
     text = "Test content for debugging the text upload issue."
     title = "DEBUG-TEST-SOURCE"

--- a/scripts/archive/test-add-source.ps1
+++ b/scripts/archive/test-add-source.ps1
@@ -3,7 +3,7 @@ $body = @{
     source_type = "text"
     text = "Debug test content - testing selectors"
     title = "Debug Test"
-    notebook_url = "https://notebooklm.google.com/notebook/abd21688-02a6-4459-953b-30f0612a984e"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000108"
     show_browser = $true
 } | ConvertTo-Json
 

--- a/scripts/archive/test-add-text-debug.ps1
+++ b/scripts/archive/test-add-text-debug.ps1
@@ -1,10 +1,10 @@
 # Test adding a text source with debug logging
 $uniqueId = (Get-Date).ToString("HHmmss")
-$notebookUrl = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+$notebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 
 Write-Host "`n=== Testing add_source (text) with debug ===" -ForegroundColor Cyan
 Write-Host "Notebook URL: $notebookUrl"
-Write-Host "Expected UUID: 3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f`n"
+Write-Host "Expected UUID: 00000000-0000-0000-0000-000000000109`n"
 
 $body = @{
     notebook_url = $notebookUrl

--- a/scripts/archive/test-delete-source.ps1
+++ b/scripts/archive/test-delete-source.ps1
@@ -1,7 +1,7 @@
 # Test 1: Add a text source
 Write-Host "=== STEP 1: Adding test source ===" -ForegroundColor Cyan
 $addBody = @{
-    notebook_url = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
     source_type = "text"
     text = "This is a test source for deletion testing. Created at $(Get-Date)"
     title = "DELETE-ME-TEST-SOURCE"
@@ -17,21 +17,21 @@ Start-Sleep -Seconds 10
 
 # List sources to verify it was added
 Write-Host "`n=== STEP 3: Listing sources to verify ===" -ForegroundColor Cyan
-$listResult = Invoke-RestMethod -Uri "http://localhost:3000/content?notebook_url=https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f" -Method GET
+$listResult = Invoke-RestMethod -Uri "http://localhost:3000/content?notebook_url=https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109" -Method GET
 $testSource = $listResult.data.sources | Where-Object { $_.name -like "*DELETE-ME*" }
 Write-Host "Found test source:" -ForegroundColor Yellow
 $testSource | ConvertTo-Json -Depth 3
 
 # Delete the source
 Write-Host "`n=== STEP 4: Deleting source by name ===" -ForegroundColor Cyan
-$deleteResult = Invoke-RestMethod -Uri "http://localhost:3000/content/sources?source_name=DELETE-ME-TEST-SOURCE&notebook_url=https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f" -Method DELETE
+$deleteResult = Invoke-RestMethod -Uri "http://localhost:3000/content/sources?source_name=DELETE-ME-TEST-SOURCE&notebook_url=https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109" -Method DELETE
 Write-Host "Delete result:" -ForegroundColor Yellow
 $deleteResult | ConvertTo-Json -Depth 5
 
 # Verify deletion
 Write-Host "`n=== STEP 5: Verifying deletion ===" -ForegroundColor Cyan
 Start-Sleep -Seconds 3
-$verifyResult = Invoke-RestMethod -Uri "http://localhost:3000/content?notebook_url=https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f" -Method GET
+$verifyResult = Invoke-RestMethod -Uri "http://localhost:3000/content?notebook_url=https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109" -Method GET
 $stillExists = $verifyResult.data.sources | Where-Object { $_.name -like "*DELETE-ME*" }
 if ($stillExists) {
     Write-Host "FAIL: Source still exists!" -ForegroundColor Red

--- a/scripts/archive/test-e2e-notebook.ps1
+++ b/scripts/archive/test-e2e-notebook.ps1
@@ -1,4 +1,4 @@
-# Test access to e2e-test-notebook with account-c
+# Test access to e2e-test-notebook with rom1pey
 Write-Host "=== Testing e2e-test-notebook with visible browser ===" -ForegroundColor Cyan
 
 # Activate it
@@ -17,5 +17,5 @@ try {
     Write-Host "SUCCESS! Answer: $($response.data.answer.Substring(0, [Math]::Min(200, $response.data.answer.Length)))..." -ForegroundColor Green
 } catch {
     Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Red
-    Write-Host "This notebook is probably not accessible to account-c" -ForegroundColor Yellow
+    Write-Host "This notebook is probably not accessible to rom1pey" -ForegroundColor Yellow
 }

--- a/scripts/archive/test-english-notebook.ps1
+++ b/scripts/archive/test-english-notebook.ps1
@@ -1,4 +1,4 @@
-# Test with the newly created notebook (owned by account-c)
+# Test with the newly created notebook (owned by rom1pey)
 $body = @{
     notebook_id = "english-test"
     source_type = "url"
@@ -9,12 +9,12 @@ $body = @{
 # First add the notebook
 $addBody = @{
     name = "english-test"
-    url = "https://notebooklm.google.com/notebook/258f62a1-8658-4f96-8333-a9e16224f602"
+    url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000110"
 } | ConvertTo-Json
 
-Write-Host "Adding notebook owned by account-c..."
+Write-Host "Adding notebook owned by rom1pey..."
 Invoke-RestMethod -Uri "http://localhost:3000/notebooks" -Method POST -ContentType "application/json" -Body $addBody -TimeoutSec 60
 
-Write-Host "`nTesting URL source on account-c's notebook..."
+Write-Host "`nTesting URL source on rom1pey's notebook..."
 $response = Invoke-RestMethod -Uri "http://localhost:3000/content/sources" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 120
 $response | ConvertTo-Json -Depth 5

--- a/scripts/archive/test-english.ps1
+++ b/scripts/archive/test-english.ps1
@@ -1,6 +1,6 @@
 $body = @{
     question = "Hello, what is this notebook about?"
-    notebook_url = "https://notebooklm.google.com/notebook/3f4e9685-333d-429e-8b82-45cee95c6748"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000111"
 } | ConvertTo-Json
 
 $response = Invoke-RestMethod -Uri "http://localhost:3000/ask" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 120

--- a/scripts/archive/test-full-custom-instructions.ps1
+++ b/scripts/archive/test-full-custom-instructions.ps1
@@ -1,5 +1,5 @@
 # Test FULL: Custom Instructions (4 tests)
-$notebookUrl = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+$notebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 $passed = 0
 $failed = 0
 

--- a/scripts/archive/test-full-infographic.ps1
+++ b/scripts/archive/test-full-infographic.ps1
@@ -1,5 +1,5 @@
 # Test FULL: Infographic Formats (2 tests)
-$notebookUrl = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+$notebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 $formats = @("horizontal", "vertical")
 
 $passed = 0

--- a/scripts/archive/test-full-language.ps1
+++ b/scripts/archive/test-full-language.ps1
@@ -1,5 +1,5 @@
 # Test FULL: Language option (1 test)
-$notebookUrl = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+$notebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 
 Write-Host "`n=== Testing language = fr ===" -ForegroundColor Cyan
 

--- a/scripts/archive/test-full-presentation.ps1
+++ b/scripts/archive/test-full-presentation.ps1
@@ -1,5 +1,5 @@
 # Test FULL: Presentation Options (5 tests)
-$notebookUrl = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+$notebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 $passed = 0
 $failed = 0
 

--- a/scripts/archive/test-full-report.ps1
+++ b/scripts/archive/test-full-report.ps1
@@ -1,5 +1,5 @@
 # Test FULL: Report Formats (2 tests)
-$notebookUrl = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+$notebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 $formats = @("summary", "detailed")
 
 $passed = 0

--- a/scripts/archive/test-full-source-selection.ps1
+++ b/scripts/archive/test-full-source-selection.ps1
@@ -1,6 +1,6 @@
 # Test FULL: Source Selection (1 test)
 Add-Type -AssemblyName System.Web
-$notebookUrl = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+$notebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 $encodedUrl = [System.Uri]::EscapeDataString($notebookUrl)
 
 Write-Host "`n=== Testing source selection ===" -ForegroundColor Cyan

--- a/scripts/archive/test-full-video-brief.ps1
+++ b/scripts/archive/test-full-video-brief.ps1
@@ -1,5 +1,5 @@
 # Test FULL: Video format = brief
-$notebookUrl = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+$notebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 
 Write-Host "`n=== FULL TEST: Video Format = brief ===" -ForegroundColor Cyan
 

--- a/scripts/archive/test-full-video-explainer.ps1
+++ b/scripts/archive/test-full-video-explainer.ps1
@@ -1,5 +1,5 @@
 # Test FULL: Video format = explainer
-$notebookUrl = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+$notebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 
 Write-Host "`n=== FULL TEST: Video Format = explainer ===" -ForegroundColor Cyan
 

--- a/scripts/archive/test-full-video-styles.ps1
+++ b/scripts/archive/test-full-video-styles.ps1
@@ -1,5 +1,5 @@
 # Test FULL: All Video Styles (6 tests)
-$notebookUrl = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+$notebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 $styles = @("classroom", "documentary", "animated", "corporate", "cinematic", "minimalist")
 
 $passed = 0

--- a/scripts/archive/test-headed-ask.ps1
+++ b/scripts/archive/test-headed-ask.ps1
@@ -1,7 +1,7 @@
 # Test /ask avec navigateur visible
 $body = @{
     question = "What is IFS therapy?"
-    notebook_url = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
     show_browser = $true
 } | ConvertTo-Json
 

--- a/scripts/archive/test-headed-now.ps1
+++ b/scripts/archive/test-headed-now.ps1
@@ -1,9 +1,9 @@
 $body = @{
     question = "Quel est le theme principal?"
-    notebook_url = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
     show_browser = $true
 } | ConvertTo-Json
 
-Write-Host "Lancement test HEADED avec account-b..."
+Write-Host "Lancement test HEADED avec mathieudumont31..."
 $response = Invoke-RestMethod -Uri "http://localhost:3000/ask" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 300
 $response | ConvertTo-Json -Depth 3

--- a/scripts/archive/test-headed.ps1
+++ b/scripts/archive/test-headed.ps1
@@ -1,9 +1,9 @@
 $body = @{
     question = "Quel est le theme principal?"
-    notebook_url = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
     headless = $false
 } | ConvertTo-Json
 
-Write-Host "Testing HEADED with account-b..."
+Write-Host "Testing HEADED with mathieudumont31..."
 $response = Invoke-RestMethod -Uri "http://localhost:3000/ask" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 180
 $response | ConvertTo-Json -Depth 10

--- a/scripts/archive/test-hello.ps1
+++ b/scripts/archive/test-hello.ps1
@@ -1,6 +1,6 @@
 $body = @{
     question = "Hello, what is this notebook about?"
-    notebook_url = "https://notebooklm.google.com/notebook/74912e55-34a4-4027-bdcc-8e89badd0efd"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000112"
 } | ConvertTo-Json
 
 $response = Invoke-RestMethod -Uri "http://localhost:3000/ask" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 120

--- a/scripts/archive/test-mathieu-quota.ps1
+++ b/scripts/archive/test-mathieu-quota.ps1
@@ -3,6 +3,6 @@ $body = @{
     show_browser = $true
 } | ConvertTo-Json
 
-Write-Host "Testing with account-b (should hit rate limit)..."
+Write-Host "Testing with mathieudumont (should hit rate limit)..."
 $response = Invoke-RestMethod -Uri "http://localhost:3000/ask" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 120
 $response | ConvertTo-Json -Depth 10

--- a/scripts/archive/test-personal-notebook.ps1
+++ b/scripts/archive/test-personal-notebook.ps1
@@ -1,6 +1,6 @@
 # Test access to personal notebook on port 3001
 $body = @{
-    url = "https://notebooklm.google.com/notebook/ce42b898-330e-45cc-96ad-ff748c1576d8"
+    url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000113"
     name = "Mon Notebook Perso"
     description = "Test notebook personnel"
     topics = @("test")

--- a/scripts/archive/test-rate-limit.ps1
+++ b/scripts/archive/test-rate-limit.ps1
@@ -1,6 +1,6 @@
 $body = @{
     question = "What is IFS therapy?"
-    notebook_url = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
     show_browser = $true
 } | ConvertTo-Json
 

--- a/scripts/archive/test-real-ask.ps1
+++ b/scripts/archive/test-real-ask.ps1
@@ -6,7 +6,7 @@ Write-Host ""
 
 # Add a test notebook
 $notebook = @{
-    url = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+    url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
     name = "Test E2E"
     description = "Notebook pour tests E2E"
     topics = @("test", "e2e")

--- a/scripts/archive/test-real-ask2.ps1
+++ b/scripts/archive/test-real-ask2.ps1
@@ -4,7 +4,7 @@ Write-Host ""
 
 $body = @{
     question = "What is this notebook about?"
-    notebook_url = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 } | ConvertTo-Json
 
 Write-Host "Asking question with direct notebook URL..."

--- a/scripts/archive/test-rom1pey.ps1
+++ b/scripts/archive/test-rom1pey.ps1
@@ -1,6 +1,6 @@
 $body = @{
     question = "Hello"
-    notebook_url = "https://notebooklm.google.com/notebook/725d28e1-4284-4f36-99a2-b6693c2ebf13"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000107"
 } | ConvertTo-Json
 
 $response = Invoke-RestMethod -Uri "http://localhost:3000/ask" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 120

--- a/scripts/archive/test-rotation-complete.ps1
+++ b/scripts/archive/test-rotation-complete.ps1
@@ -4,7 +4,7 @@ $body = @{
 } | ConvertTo-Json
 
 Write-Host "=== TEST ROTATION COMPLETE ===" -ForegroundColor Cyan
-Write-Host "1. Demarrage avec account-b (quota 50/50)"
+Write-Host "1. Demarrage avec mathieudumont (quota 50/50)"
 Write-Host "2. Attend erreur 'Le systeme n'a pas pu repondre'"
 Write-Host "3. Detection rate limit -> switch compte"
 Write-Host "4. Retry avec nouveau compte"

--- a/scripts/archive/test-rotation.ps1
+++ b/scripts/archive/test-rotation.ps1
@@ -1,8 +1,8 @@
 $body = @{
     question = "Bonjour, quel est le sujet principal de ce notebook?"
-    notebook_url = "https://notebooklm.google.com/notebook/3e79b7be-9a72-4ac7-aaf7-ac3f450fa96f"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000109"
 } | ConvertTo-Json
 
-Write-Host "Testing account rotation with rate-limited account-b..."
+Write-Host "Testing account rotation with rate-limited mathieudumont31..."
 $response = Invoke-RestMethod -Uri "http://localhost:3000/ask" -Method POST -ContentType "application/json" -Body $body -TimeoutSec 120
 $response | ConvertTo-Json -Depth 10

--- a/scripts/archive/test-show-browser.ps1
+++ b/scripts/archive/test-show-browser.ps1
@@ -2,7 +2,7 @@
 # This tests whether show_browser=true makes the browser visible
 
 $baseUrl = "http://localhost:3000"
-$notebookUrl = "https://notebooklm.google.com/notebook/abd21688-02a6-4459-953b-30f0612a984e"
+$notebookUrl = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000108"
 
 Write-Host "=== Testing show_browser parameter ===" -ForegroundColor Cyan
 

--- a/scripts/archive/test-update-notebook.ps1
+++ b/scripts/archive/test-update-notebook.ps1
@@ -1,4 +1,4 @@
 $body = @{
     description = "Updated by E2E test at $(Get-Date -Format 'yyyy-MM-dd HH:mm:ss')"
 } | ConvertTo-Json
-Invoke-RestMethod -Uri "http://localhost:3000/notebooks/e2e-account-c-test" -Method PUT -ContentType "application/json" -Body $body
+Invoke-RestMethod -Uri "http://localhost:3000/notebooks/e2e-rom1pey-test" -Method PUT -ContentType "application/json" -Body $body

--- a/scripts/archive/verify-language-slow.ps1
+++ b/scripts/archive/verify-language-slow.ps1
@@ -2,7 +2,7 @@
 # Opens browser and waits so you can check the UI language
 
 $body = @{
-    notebook_url = "https://notebooklm.google.com/notebook/725d28e1-4284-4f36-99a2-b6693c2ebf13"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000107"
     question = "Hello, what language is the UI in?"
     show_browser = $true
     browser_options = @{

--- a/scripts/archive/verify-language.ps1
+++ b/scripts/archive/verify-language.ps1
@@ -2,7 +2,7 @@
 # Opens browser to check if UI is in English
 
 $body = @{
-    notebook_url = "https://notebooklm.google.com/notebook/725d28e1-4284-4f36-99a2-b6693c2ebf13"
+    notebook_url = "https://notebooklm.google.com/notebook/00000000-0000-0000-0000-000000000107"
     question = "What is this notebook about?"
     show_browser = $true
 } | ConvertTo-Json

--- a/scripts/mcp-wsl-helper.sh
+++ b/scripts/mcp-wsl-helper.sh
@@ -13,7 +13,7 @@
 set -e
 
 MCP_PORT=3000
-MCP_DIR="${NOTEBOOKLM_MCP_DIR:-D:/path/to/notebooklm-mcp}"
+MCP_DIR="D:/path/to/notebooklm-mcp"
 
 # Helper function to call the API via PowerShell (bypasses WSL network issues)
 call_api() {

--- a/scripts/start-server-hidden.vbs
+++ b/scripts/start-server-hidden.vbs
@@ -1,15 +1,16 @@
 ' NotebookLM MCP Server - hidden startup helper
 ' Starts the HTTP server without opening a visible console window.
 
-Dim fso, shell, scriptDir, projectDir
+Dim fso
+Dim shell
+Dim scriptDir
+Dim projectDir
+
 Set fso = CreateObject("Scripting.FileSystemObject")
 Set shell = CreateObject("WScript.Shell")
 
-' Resolve the project root dynamically from the script location
 scriptDir = fso.GetParentFolderName(WScript.ScriptFullName)
 projectDir = fso.GetParentFolderName(scriptDir)
 
 shell.CurrentDirectory = projectDir
-
-' Launch the server in hidden mode (0 = hidden)
 shell.Run "node dist/http-wrapper.js", 0, False

--- a/scripts/switch-account-language.sh
+++ b/scripts/switch-account-language.sh
@@ -1,191 +1,150 @@
 #!/bin/bash
 # Switch Account Language Script
 #
-# This script automates the process of switching an account to a new language.
-# It deletes the Chrome profile cache and re-authenticates to get a fresh profile
-# with the new language settings from Google Account.
-#
-# PREREQUISITE: You must first change the language in Google Account settings:
-# https://myaccount.google.com/language
-#
-# Usage:
-#   ./switch-account-language.sh --account=account-a --lang=en
-#   ./switch-account-language.sh --account=account-b --lang=fr
-#   ./switch-account-language.sh --account=account-c --lang=en --show
+# Refreshes one account profile after the user changes the Google Account
+# language. This script is intentionally generic: you provide the account ID,
+# repo root, and optionally the NotebookLM data directory.
 
-set -e
+set -euo pipefail
 
-# Default values
-ACCOUNT=""
+ACCOUNT_ID=""
 LANG=""
 SHOW_BROWSER=""
+REPO_ROOT=""
+DATA_PATH="${NOTEBOOKLM_DATA_PATH:-}"
 
-# Account configurations — edit for your own accounts
-declare -A ACCOUNT_IDS=(
-  ["account-a"]="account-0000000000001"
-  ["account-b"]="account-0000000000002"
-  ["account-c"]="account-0000000000003"
-)
+usage() {
+  echo "Switch Account Language Script"
+  echo ""
+  echo "Prerequisite:"
+  echo "  Change the Google Account language first:"
+  echo "  https://myaccount.google.com/language"
+  echo ""
+  echo "Usage:"
+  echo "  ./scripts/switch-account-language.sh --account-id=account-0000000000001 --lang=en --repo-root=/absolute/path/to/notebooklm-mcp"
+  echo ""
+  echo "Options:"
+  echo "  --account-id=ID   Account directory ID under Data/accounts/ (required)"
+  echo "  --lang=LANG       Target UI locale: en|fr (required)"
+  echo "  --repo-root=PATH  Repo root containing package.json (required unless run there)"
+  echo "  --data-path=PATH  NotebookLM data directory override"
+  echo "  --show            Show browser during re-authentication"
+  echo "  --help            Show this help"
+}
 
-declare -A ACCOUNT_EMAILS=(
-  ["account-a"]="your-account-a@example.com"
-  ["account-b"]="your-account-b@example.com"
-  ["account-c"]="your-account-c@example.com"
-)
-
-# Data path — override via NOTEBOOKLM_DATA_PATH env var
-DATA_PATH="${NOTEBOOKLM_DATA_PATH:-/mnt/c/Users/$USER/AppData/Local/notebooklm-mcp/Data}"
-
-# Parse arguments
 for arg in "$@"; do
   case $arg in
-    --account=*)
-      ACCOUNT="${arg#*=}"
+    --account-id=*)
+      ACCOUNT_ID="${arg#*=}"
       ;;
     --lang=*)
       LANG="${arg#*=}"
+      ;;
+    --repo-root=*)
+      REPO_ROOT="${arg#*=}"
+      ;;
+    --data-path=*)
+      DATA_PATH="${arg#*=}"
       ;;
     --show)
       SHOW_BROWSER="--show"
       ;;
     --help)
-      echo "Switch Account Language Script"
-      echo ""
-      echo "PREREQUISITE: Change language in Google Account first:"
-      echo "  https://myaccount.google.com/language"
-      echo ""
-      echo "Usage: ./switch-account-language.sh [options]"
-      echo ""
-      echo "Options:"
-      echo "  --account=NAME    Account key from ACCOUNT_IDS (required)"
-      echo "  --lang=LANG       Target language: en|fr (required)"
-      echo "  --show            Show browser during re-authentication"
-      echo "  --help            Show this help"
-      echo ""
-      echo "Examples:"
-      echo "  ./switch-account-language.sh --account=account-a --lang=en"
-      echo "  ./switch-account-language.sh --account=account-b --lang=fr --show"
+      usage
       exit 0
+      ;;
+    *)
+      echo "ERROR: Unknown argument: $arg"
+      usage
+      exit 1
       ;;
   esac
 done
 
-# Validate arguments
-if [ -z "$ACCOUNT" ]; then
-  echo "ERROR: --account is required"
-  echo "Use --help for usage information"
+if [ -z "$ACCOUNT_ID" ]; then
+  echo "ERROR: --account-id is required"
+  usage
   exit 1
 fi
 
 if [ -z "$LANG" ]; then
   echo "ERROR: --lang is required"
-  echo "Use --help for usage information"
-  exit 1
-fi
-
-if [ -z "${ACCOUNT_IDS[$ACCOUNT]}" ]; then
-  echo "ERROR: Unknown account '$ACCOUNT'"
-  echo "Valid accounts: ${!ACCOUNT_IDS[*]}"
+  usage
   exit 1
 fi
 
 if [ "$LANG" != "en" ] && [ "$LANG" != "fr" ]; then
-  echo "ERROR: Invalid language '$LANG'"
-  echo "Valid languages: en, fr"
+  echo "ERROR: --lang must be en or fr"
   exit 1
 fi
 
-ACCOUNT_ID="${ACCOUNT_IDS[$ACCOUNT]}"
-ACCOUNT_EMAIL="${ACCOUNT_EMAILS[$ACCOUNT]}"
+if [ -z "$REPO_ROOT" ]; then
+  if [ -f "./package.json" ]; then
+    REPO_ROOT="$(pwd)"
+  else
+    echo "ERROR: --repo-root is required unless you run the script from the repo root"
+    exit 1
+  fi
+fi
 
-echo "╔════════════════════════════════════════════════════════════╗"
-echo "║  Switch Account Language                                    ║"
-echo "╠════════════════════════════════════════════════════════════╣"
-echo "║  Account: $ACCOUNT ($ACCOUNT_EMAIL)"
-echo "║  Target:  $LANG"
-echo "╚════════════════════════════════════════════════════════════╝"
+if [ ! -f "$REPO_ROOT/package.json" ]; then
+  echo "ERROR: package.json not found in repo root: $REPO_ROOT"
+  exit 1
+fi
+
+if [ -z "$DATA_PATH" ]; then
+  if [ -n "${LOCALAPPDATA:-}" ]; then
+    DATA_PATH="${LOCALAPPDATA}/notebooklm-mcp/Data"
+  else
+    echo "ERROR: data path not set. Use --data-path or NOTEBOOKLM_DATA_PATH."
+    exit 1
+  fi
+fi
+
+echo "Switching account language"
+echo "  account-id: $ACCOUNT_ID"
+echo "  locale:     $LANG"
+echo "  repo-root:  $REPO_ROOT"
+echo "  data-path:  $DATA_PATH"
 echo ""
 
-# Step 1: Stop server and Chrome
-echo "Step 1/5: Stopping server and Chrome..."
+echo "Step 1/5: Stopping repo-related Node processes..."
 cmd.exe /c "taskkill /F /IM node.exe" 2>/dev/null || true
 sleep 1
-# Only kill Chrome if profile is locked (don't kill user's personal browser)
-if [ -f "$DATA_PATH/chrome_profile/lockfile" ] 2>/dev/null; then
-  echo "  Chrome profile locked, killing Chrome..."
-  cmd.exe /c "taskkill /F /IM chrome.exe" 2>/dev/null || true
-  sleep 2
-fi
-echo "  Done."
 
-# Step 2: Delete account's Chrome profile (to clear language cache)
-echo ""
-echo "Step 2/5: Deleting Chrome profile cache for $ACCOUNT..."
+echo "Step 2/5: Removing cached profile for the selected account..."
 ACCOUNT_PROFILE="$DATA_PATH/accounts/$ACCOUNT_ID/profile"
 if [ -d "$ACCOUNT_PROFILE" ]; then
   rm -rf "$ACCOUNT_PROFILE"
-  echo "  Deleted: $ACCOUNT_PROFILE"
+  echo "  Removed $ACCOUNT_PROFILE"
 else
-  echo "  Profile not found (already clean)"
+  echo "  No account profile found to remove"
 fi
-echo "  Done."
 
-# Step 3: Re-authenticate to create fresh profile
-echo ""
-echo "Step 3/5: Re-authenticating $ACCOUNT..."
-echo "  This will open a browser to log in with the new language settings."
-echo ""
+echo "Step 3/5: Re-authenticating the selected account..."
+cmd.exe /c "cd /d $REPO_ROOT && npm run accounts test $ACCOUNT_ID -- $SHOW_BROWSER"
 
-cd /mnt/d/path/to/notebooklm-mcp
-cmd.exe /c "cd /d D:\\path\\to\\notebooklm-mcp && npm run accounts test $ACCOUNT_ID -- $SHOW_BROWSER"
-
-echo "  Done."
-
-# Step 4: Sync new profile to main
-echo ""
-echo "Step 4/5: Syncing new profile to main..."
-
-# Sync state.json
+echo "Step 4/5: Syncing the refreshed profile into the active data path..."
 if [ -f "$DATA_PATH/accounts/$ACCOUNT_ID/browser_state/state.json" ]; then
-  cp "$DATA_PATH/accounts/$ACCOUNT_ID/browser_state/state.json" "$DATA_PATH/browser_state/"
-  echo "  Synced state.json"
+  mkdir -p "$DATA_PATH/browser_state"
+  cp "$DATA_PATH/accounts/$ACCOUNT_ID/browser_state/state.json" "$DATA_PATH/browser_state/state.json"
+  echo "  Synced browser_state/state.json"
 else
-  echo "  WARNING: state.json not found"
+  echo "  WARNING: browser_state/state.json not found for $ACCOUNT_ID"
 fi
 
-# Sync Chrome profile
 rm -rf "$DATA_PATH/chrome_profile" 2>/dev/null || true
 if [ -d "$DATA_PATH/accounts/$ACCOUNT_ID/profile" ]; then
   cp -r "$DATA_PATH/accounts/$ACCOUNT_ID/profile" "$DATA_PATH/chrome_profile"
-  echo "  Synced Chrome profile"
+  echo "  Synced chrome_profile/"
 else
-  echo "  WARNING: Chrome profile not found"
+  echo "  WARNING: refreshed profile not found for $ACCOUNT_ID"
 fi
-echo "  Done."
 
-# Step 5: Restart server with correct locale
-echo ""
-echo "Step 5/5: Starting server with UI locale '$LANG'..."
-
-# Convert lang to uppercase for display
-LANG_UPPER=$(echo "$LANG" | tr '[:lower:]' '[:upper:]')
-
-cmd.exe /c "cd /d D:\\path\\to\\notebooklm-mcp && set NOTEBOOKLM_UI_LOCALE=$LANG&& start /B node dist/http-wrapper.js" &
+echo "Step 5/5: Restarting the HTTP server with the requested locale..."
+cmd.exe /c "cd /d $REPO_ROOT && set NOTEBOOKLM_UI_LOCALE=$LANG&& start /B node dist/http-wrapper.js" >/dev/null
 sleep 4
 
-# Verify
 echo ""
-echo "Verifying server..."
-HEALTH=$(cmd.exe /c "curl -s http://localhost:3000/health" 2>/dev/null || echo '{"error":"failed"}')
-echo "$HEALTH" | head -c 200
-
-echo ""
-echo ""
-echo "╔════════════════════════════════════════════════════════════╗"
-echo "║  COMPLETED                                                  ║"
-echo "╠════════════════════════════════════════════════════════════╣"
-echo "║  Account '$ACCOUNT' is now configured for '$LANG_UPPER'."
-echo "║                                                             ║"
-echo "║  IMPORTANT: Verify visually that NotebookLM UI is in $LANG_UPPER    ║"
-echo "║  by running a test with show_browser:true                   ║"
-echo "╚════════════════════════════════════════════════════════════╝"
+echo "Health check:"
+cmd.exe /c "curl -s http://127.0.0.1:3000/health" || true

--- a/tests/e2e/archive/E2E-MATHIEU-EN-FULL.md
+++ b/tests/e2e/archive/E2E-MATHIEU-EN-FULL.md
@@ -1,7 +1,7 @@
-# E2E Tests FULL - account-a Account (English UI)
+# E2E Tests FULL - test-account-a (English UI)
 
 **Date:** 2025-12-31
-**Account:** your-account-a@example.com (English UI)
+**Account:** test-account-a@example.com (English UI)
 **Notebook:** A CREER
 **Mode:** FULL (76 tests)
 

--- a/tests/e2e/archive/E2E-ROM1PEY-EN-FULL.md
+++ b/tests/e2e/archive/E2E-ROM1PEY-EN-FULL.md
@@ -1,8 +1,8 @@
-# E2E Tests FULL - account-c Account (English UI)
+# E2E Tests FULL - test-account-c (English UI)
 
 **Date:** 2025-12-31
-**Account:** your-account-c@example.com (English UI)
-**Notebook:** e2e-account-c-test (725d28e1-4284-4f36-99a2-b6693c2ebf13)
+**Account:** test-account-c@example.com (English UI)
+**Notebook:** e2e-test-notebook-c (00000000-0000-0000-0000-000000000107)
 **Mode:** FULL (76 tests)
 
 ---

--- a/tests/e2e/archive/E2E-ROM1PEY-EN-STATUS.md
+++ b/tests/e2e/archive/E2E-ROM1PEY-EN-STATUS.md
@@ -1,8 +1,8 @@
-# E2E Tests - account-c Account (English UI)
+# E2E Tests - test-account-c (English UI)
 
 **Date:** 2025-12-31
-**Account:** your-account-c@example.com (English UI)
-**Notebook:** e2e-account-c-test (725d28e1-4284-4f36-99a2-b6693c2ebf13)
+**Account:** test-account-c@example.com (English UI)
+**Notebook:** e2e-test-notebook-c (00000000-0000-0000-0000-000000000107)
 **Server Version:** 1.4.2
 
 ---

--- a/tests/e2e/archive/E2E-ROM1PEY-TRACKING.md
+++ b/tests/e2e/archive/E2E-ROM1PEY-TRACKING.md
@@ -1,7 +1,7 @@
-# E2E Tests Tracking - account-c Account (English)
+# E2E Tests Tracking - test-account-c (English)
 
-**Account:** your-account-c@example.com
-**Notebook:** e2e-account-c-test (725d28e1-4284-4f36-99a2-b6693c2ebf13)
+**Account:** test-account-c@example.com
+**Notebook:** e2e-test-notebook-c (00000000-0000-0000-0000-000000000107)
 **Started:** 2025-12-31
 
 ## Test Status


### PR DESCRIPTION
## Summary

This isolates the PII / hardcoded-data scrub from the earlier broad draft.

## What changed

- scrubbed archived scripts of hardcoded notebook URLs, UUIDs, and account-specific values
- removed concrete notebook IDs from API and notebook-library docs
- replaced the public auto-discovery test notebook list with user-supplied placeholders
- sanitized archived E2E notes so they use generic test-account names
- kept this PR focused on redaction/scrub work only

## Notes

- I left the root AI onboarding files and the broad docs rewrites out of this resubmission
- `scripts/archive/change-language.mjs` and `scripts/archive/change-language.ts` were intentionally not carried over from the broad draft, so the hardcoded local path does not come along here

## Verification

- `git diff --check`
- `npm run build`
