### PR TITLE
security: harden release pipeline against npm supply-chain attacks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,34 +1,121 @@
 name: Release
 
+# Two-job split per codex round-3 B2 (Shai-Hulud hardening):
+#   - build:   runs lifecycle-script-free `npm pack` in a permissions-restricted job
+#              (NO id-token), uploads the .tgz + sha256 as an artifact
+#   - publish: downloads artifact, verifies sha256, publishes from the .tgz file
+#              with id-token: write and a protected GitHub Environment gate
+#
+# Trusted Publishing (OIDC) is configured at:
+#   https://www.npmjs.com/package/@roomi-fields/notebooklm-mcp/access
+#   → Trusted Publishers → Add GitHub Actions
+#   See /tmp/shai-hulud-p5-deploy.md for full setup instructions.
+#
+# No NPM_TOKEN secret is needed once Trusted Publishing is live. Provenance is
+# produced automatically by npm when published from a Trusted Publisher OIDC
+# context, but we keep the `--provenance` flag explicit so the publish still
+# works as a fallback if Trusted Publishing is briefly disabled.
+
 on:
   push:
     tags:
       - 'v*'
 
+# Top-level permissions = read-only. Each job opts in to what it needs.
 permissions:
-  contents: write
-  id-token: write
+  contents: read
 
 jobs:
-  release:
+  build:
+    name: Build & pack (no scripts, no OIDC)
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          node-version: '22.14.0'
           registry-url: 'https://registry.npmjs.org'
+          cache: ''
+          package-manager-cache: false
 
-      - name: Install dependencies
-        run: npm ci
+      - name: Pin npm to >= 11.5.1
+        run: npm install --global --ignore-scripts npm@11.5.1
 
-      - name: Build
-        run: npm run build
+      - name: Install deps (no scripts)
+        run: npm ci --ignore-scripts
 
-      - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Build (explicit, not via lifecycle)
+        run: npm run build --ignore-scripts
+
+      - name: Pack tarball (no scripts)
+        id: pack
+        run: |
+          set -euo pipefail
+          PACK_JSON=$(npm pack --ignore-scripts --json)
+          echo "$PACK_JSON" > pack.json
+          TGZ=$(node -e "console.log(require('./pack.json')[0].filename)")
+          echo "tgz=$TGZ" >> "$GITHUB_OUTPUT"
+          mkdir -p out
+          mv "$TGZ" "out/$TGZ"
+          (cd out && sha256sum "$TGZ" > "$TGZ.sha256")
+          echo "Produced: out/$TGZ"
+          cat "out/$TGZ.sha256"
+
+      - name: Upload package artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: npm-package
+          path: |
+            out/*.tgz
+            out/*.tgz.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish to npm (Trusted Publisher)
+    needs: build
+    runs-on: ubuntu-latest
+    # Protected GitHub environment — requires manual approval by Bryan on every
+    # tag push before npm credentials are available to the job.
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22.14.0'
+          registry-url: 'https://registry.npmjs.org'
+          cache: ''
+          package-manager-cache: false
+
+      - name: Pin npm to >= 11.5.1
+        run: npm install --global --ignore-scripts npm@11.5.1
+
+      - name: Download package artifact
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: npm-package
+          path: pkg
+
+      - name: Verify sha256 of artifact
+        working-directory: pkg
+        run: |
+          set -euo pipefail
+          ls -la
+          sha256sum -c *.tgz.sha256
+          # Resolve the tarball filename for the publish step.
+          TGZ=$(ls *.tgz)
+          echo "TGZ=$TGZ" >> "$GITHUB_ENV"
+
+      - name: Publish to npm with provenance (Trusted Publisher OIDC)
+        working-directory: pkg
+        run: npm publish "./$TGZ" --ignore-scripts --provenance --access public


### PR DESCRIPTION
## Why this PR

The **Shai-Hulud npm self-replicating worm** has active waves in May 2026 (AntV cluster on May 19, TanStack cluster on May 11). The worm targets npm publish pipelines: a single compromised transitive dependency runs as a `postinstall` lifecycle script inside the same CI job that holds publishing credentials, then exfiltrates the npm token (or, increasingly, the OIDC publish token) and pushes worm-bearing versions of every package the maintainer can publish to.

`@roomi-fields/notebooklm-mcp` is currently vulnerable in two ways:

1. The release workflow runs `npm ci` (which invokes every dep's lifecycle scripts) in the **same job** that has `id-token: write` and access to `NPM_TOKEN`.
2. The workflow uses floating action tags (`actions/checkout@v4`) and unpinned npm/Node versions, so a compromised action release would silently land in the publish step.

## What this PR changes

The release workflow is restructured to remove the single-job blast radius:

**1. Two-job split with separated trust boundaries**
- `build` job: runs `npm ci`, `npm run build`, and `npm pack` with `--ignore-scripts` on every step. **No `id-token`**, no publish credentials, no environment. It produces `out/<pkg>.tgz` + `out/<pkg>.tgz.sha256` as a CI artifact.
- `publish` job: downloads the artifact, verifies the sha256, and publishes the prebuilt tarball with `--ignore-scripts --provenance --access public`. **Only this job** holds `id-token: write`, and it is gated by a protected GitHub Environment (`npm-publish`) requiring manual reviewer approval.

A worm in a transitive dep can no longer reach the publish credentials, because lifecycle scripts never execute in the same job that holds them.

**2. `--ignore-scripts` everywhere**
Applied to `npm install`, `npm ci`, `npm run build`, `npm pack`, and `npm publish`. The package's own `prepare: husky` script does not need to run in CI (husky only sets up local git hooks). Dep `preinstall`/`install`/`postinstall`/`prepare`/`prepack`/`prepublishOnly` are all suppressed.

**3. OIDC Trusted Publishing instead of a long-lived `NPM_TOKEN`**
The publish step uses npm's Trusted Publisher OIDC handshake (no static token in repo secrets). This eliminates the npm-token exfiltration class of attack entirely.

**4. SHA-pinned actions**
`actions/checkout`, `actions/setup-node`, `actions/upload-artifact`, `actions/download-artifact` are all pinned to 40-char commit SHAs with a `# vX.Y.Z` comment. A compromised action release cannot land silently.

**5. Pinned npm CLI and Node version**
`node@22.14.0` and `npm@11.5.1` are the current minimums for the OIDC/Trusted-Publisher flow per https://docs.npmjs.com/trusted-publishers. setup-node caching is disabled (`cache: ''`, `package-manager-cache: false`) to remove a low-probability cache-poisoning vector.

**6. Top-level read-only permissions**
The workflow now sets `permissions: contents: read` at the top level. Each job opts in to only what it needs.

## What Romain needs to do upstream to activate this

The workflow file change alone is **not sufficient** — the OIDC handshake will fail with `403 Forbidden – cannot publish without authentication` until two upstream-only steps are completed.

### Step 1 — Configure Trusted Publishing on npmjs.com

> Bryan cannot do this. It must be done by the npm account that owns `@roomi-fields/notebooklm-mcp` (i.e. Romain or an org admin).

1. Log in at https://www.npmjs.com with the owner account.
2. Go to **Packages → `@roomi-fields/notebooklm-mcp` → Settings → Trusted publishing**
   (direct URL: https://www.npmjs.com/package/@roomi-fields/notebooklm-mcp/access).
3. Click **Add trusted publisher → GitHub Actions**.
4. Fill in:
   - **Organization or user:** `roomi-fields`
   - **Repository:** `notebooklm-mcp`
   - **Workflow filename:** `release.yml`
   - **Environment name:** `npm-publish` (must match exactly)
   - **Allowed actions:** check `npm publish`
5. Save.

Once Trusted Publishing is active, delete the old `NPM_TOKEN` repository secret at
https://github.com/roomi-fields/notebooklm-mcp/settings/secrets/actions — keep it for the rollback window first, see "Rollback" below.

### Step 2 — Create the protected `npm-publish` GitHub Environment

The workflow's `publish` job references `environment: npm-publish`. This is a second lock: even if OIDC is misconfigured, the publish job cannot start until a human approves.

1. Go to https://github.com/roomi-fields/notebooklm-mcp/settings/environments.
2. Click **New environment** → name it `npm-publish` exactly.
3. Under **Deployment protection rules**:
   - Enable **Required reviewers** and add Romain (and Bryan if he has push access).
   - Enable **Restrict deployments to selected branches and tags** → tag pattern `v*`.
4. Do **not** add any environment secrets. Trusted Publishing supplies the credentials via OIDC.
5. Save.

## Smoke-test recipe (after merging this PR)

Once both upstream steps above are complete and this PR is merged, validate end-to-end with a discardable prerelease tag. There is no `--dry-run` for the OIDC handshake; a real publish is the only way to fully verify the chain.

```bash
cd notebooklm-mcp
git checkout main && git pull
npm version 1.5.10-trusted.0 --no-git-tag-version --ignore-scripts
git add package.json && git commit -m "test: trusted-publisher smoke"
git tag v1.5.10-trusted.0
git push origin main --tags
```

Expected behaviour:

1. **Build job** runs immediately, completes green, uploads `npm-package` artifact (`.tgz` + `.tgz.sha256`).
2. **Publish job** queues but blocks on the `npm-publish` environment's required-reviewer gate. You should see a yellow "Waiting" status.
3. Approve the deployment. Publish job resumes, downloads artifact, verifies sha256, publishes.
4. https://www.npmjs.com/package/@roomi-fields/notebooklm-mcp/v/1.5.10-trusted.0 should show **"Published via GitHub Actions"** with a provenance badge.
5. `npm view @roomi-fields/notebooklm-mcp@1.5.10-trusted.0 dist.attestations` returns non-empty attestation URLs.
6. Immediately deprecate the test version:
   ```bash
   npm deprecate '@roomi-fields/notebooklm-mcp@1.5.10-trusted.0' \
     "Trusted-publisher smoke test - do not install"
   ```

Use a `-trusted.N` prerelease suffix so semver `^1.5` consumers will not pick it up.

## Rollback

If the new workflow misbehaves:

1. **Revert this commit** on `main`:
   ```bash
   git revert <merge-sha>
   git push origin main
   ```
   This restores the single-job workflow. The old version still works **only if** `NPM_TOKEN` is still in repo secrets — so do **not** delete `NPM_TOKEN` until the smoke test above is fully green.
2. **Disable Trusted Publishing on npm**: go back to https://www.npmjs.com/package/@roomi-fields/notebooklm-mcp/access → Trusted publishing → remove the GitHub Actions entry. The package falls back to classic token auth.
3. **Manual publish in emergency**: from a clean local machine, `npm publish --provenance --access public` after `npm login` works. Use a fresh, scoped, automation-only npm token; revoke immediately after.
4. **Delete the GitHub Environment last**: removing it before reverting the workflow will error with `environment 'npm-publish' not found`.

## Notes on what is intentionally not changed

- The package's `prepare: husky` script in `package.json` is untouched. It does not run in CI because every npm command in the workflow uses `--ignore-scripts`. Husky still works for local devs running `npm install` normally.
- No source code or runtime dependency changes. This is a CI-only patch.
- The `--provenance` flag is kept explicit on the publish step. Trusted Publishing emits provenance automatically, but the explicit flag is a no-op safety net if Trusted Publishing is briefly disabled during rollback.

## Background reading

- npm Trusted Publishers docs: https://docs.npmjs.com/trusted-publishers
- GitHub OIDC for cloud providers: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect
- Shai-Hulud worm analysis (Socket): https://socket.dev/blog/shai-hulud-npm-worm
